### PR TITLE
[release/2.11] Pass extension sources as str, not pathlib.Path

### DIFF
--- a/tools/setup_helpers/extension.py
+++ b/tools/setup_helpers/extension.py
@@ -117,8 +117,8 @@ def get_ext_modules():
         extension(
             name="torchaudio.lib._torchaudio",
             sources=[
-                _CSRC_DIR / "_torchaudio.cpp",
-                _CSRC_DIR / "utils.cpp",
+                str(_CSRC_DIR / "_torchaudio.cpp"),
+                str(_CSRC_DIR / "utils.cpp"),
             ],
             py_limited_api=True,
             extra_compile_args=extra_compile_args,
@@ -126,7 +126,7 @@ def get_ext_modules():
         ),
         extension(
             name="torchaudio.lib.libtorchaudio",
-            sources=[_CSRC_DIR / s for s in sources],
+            sources=[str(_CSRC_DIR / s) for s in sources],
             py_limited_api=True,
             extra_compile_args=extra_compile_args,
             include_dirs=[_CSRC_DIR.parent],
@@ -138,7 +138,7 @@ def get_ext_modules():
                 extension(
                     name="torchaudio.lib.torchaudio_prefixctc",
                     sources=[
-                        _CSRC_DIR / "cuctc" / "src" / s
+                        str(_CSRC_DIR / "cuctc" / "src" / s)
                         for s in ["ctc_prefix_decoder.cpp", "ctc_prefix_decoder_kernel_v2.cu", "python_binding.cpp"]
                     ],
                     py_limited_api=True,


### PR DESCRIPTION
> Part of the ROCm release/2.11 wheel-build fix stack tracked by ROCm/pytorch#3477 (all pieces validated together in one combined green build). Jira: https://amd-hub.atlassian.net/browse/AIPYTORCH-827

## Why

The ROCm release/2.11 wheel-stack build fails while building torchaudio:

```
File ".../tools/setup_helpers/extension.py", line ..., in get_ext_modules
    extension(
  ...
  File ".../setuptools/_distutils/extension.py", line 110, in __init__
    raise AssertionError("'sources' must be a list of strings")
AssertionError: 'sources' must be a list of strings
```

`get_ext_modules()` builds the extension `sources` lists from `_CSRC_DIR / "..."`, i.e. `pathlib.Path` objects. Older setuptools accepted `os.PathLike`, but the newer setuptools/distutils in the build image now asserts that `sources` is a list of `str`.

## Fix

Wrap each source path in `str()`. `include_dirs` are left unchanged (distutils does not assert on them).

